### PR TITLE
KAS-4100 changed isAgendaVoor to behandelt to ensure closed agenda

### DIFF
--- a/lib/sign-flows.js
+++ b/lib/sign-flows.js
@@ -24,7 +24,7 @@ WHERE {
   ?agenda dct:hasPart ?agendaItem .
   FILTER NOT EXISTS { [] prov:wasRevisionOf ?agenda }
 
-  ?agenda besluitvorming:isAgendaVoor ?meeting .
+  ?meeting besluitvorming:behandelt ?agenda .
   ?meeting besluit:geplandeStart ?meetingDate .
   FILTER (?meetingDate >= ${sparqlEscapeDateTime(date)})
 


### PR DESCRIPTION
Prevents a weird, semi-fictional situation where an agenda is closed, decisions are published, after which the agenda is reopened.

This practically wouldn't happen, but technically it can.
This then results in the previous agenda versions documents still being listed in the shortlist, when they shouldn't be.

Simple fix: get the meeting using `besluitvorming:behandelt`, which is only set on closed agendas.

Sidenote: I was surprised to see that the `FILTER NOT EXISTS { [] prov:wasRevisionOf ?agenda }` didn't account for this case. Can't really explain why...